### PR TITLE
ReadBody fails when variables are provided

### DIFF
--- a/src/GraphQL.Attachments/RequestReader.cs
+++ b/src/GraphQL.Attachments/RequestReader.cs
@@ -45,7 +45,7 @@ namespace GraphQL.Attachments
         {
             public string operationName { get; set; } = null!;
             public string query { get; set; } = null!;
-            public JObject variables { get; set; } = null!;
+            public object variables { get; set; } = null!;
         }
 
         internal static async Task<(string query, Inputs inputs, string operation)> ReadBody(
@@ -53,7 +53,10 @@ namespace GraphQL.Attachments
             CancellationToken cancellation)
         {
             var postBody = await JsonSerializer.DeserializeAsync<PostBody>(stream, cancellationToken: cancellation);
-            return (postBody!.query, postBody.variables.ToInputs(), postBody.operationName);
+
+            var variables = postBody.variables?.ToString() ?? string.Empty;
+
+            return (postBody!.query, variables.ToInputs(), postBody.operationName);
         }
 
         static async Task<(string query, Inputs inputs, IIncomingAttachments attachments, string? operation)> ReadForm(

--- a/src/Tests/RequestReaderTests.ParsingWithVariables.verified.txt
+++ b/src/Tests/RequestReaderTests.ParsingWithVariables.verified.txt
@@ -1,0 +1,7 @@
+{
+  query: '{\n  noAttachment\n  {\n    argument\n  }\n}',
+  inputs: {
+    key: 'value'
+  },
+  operation: 'theOperation'
+}

--- a/src/Tests/RequestReaderTests.cs
+++ b/src/Tests/RequestReaderTests.cs
@@ -34,6 +34,12 @@ public class RequestReaderTests :
         return Parse("{\"query\":\"\\n    query IntrospectionQuery {\\n      __schema {\\n        queryType { name }\\n        mutationType { name }\\n        subscriptionType { name }\\n        types {\\n          ...FullType\\n        }\\n        directives {\\n          name\\n          description\\n          locations\\n          args {\\n            ...InputValue\\n          }\\n        }\\n      }\\n    }\\n\\n    fragment FullType on __Type {\\n      kind\\n      name\\n      description\\n      fields(includeDeprecated: true) {\\n        name\\n        description\\n        args {\\n          ...InputValue\\n        }\\n        type {\\n          ...TypeRef\\n        }\\n        isDeprecated\\n        deprecationReason\\n      }\\n      inputFields {\\n        ...InputValue\\n      }\\n      interfaces {\\n        ...TypeRef\\n      }\\n      enumValues(includeDeprecated: true) {\\n        name\\n        description\\n        isDeprecated\\n        deprecationReason\\n      }\\n      possibleTypes {\\n        ...TypeRef\\n      }\\n    }\\n\\n    fragment InputValue on __InputValue {\\n      name\\n      description\\n      type { ...TypeRef }\\n      defaultValue\\n    }\\n\\n    fragment TypeRef on __Type {\\n      kind\\n      name\\n      ofType {\\n        kind\\n        name\\n        ofType {\\n          kind\\n          name\\n          ofType {\\n            kind\\n            name\\n            ofType {\\n              kind\\n              name\\n              ofType {\\n                kind\\n                name\\n                ofType {\\n                  kind\\n                  name\\n                  ofType {\\n                    kind\\n                    name\\n                  }\\n                }\\n              }\\n            }\\n          }\\n        }\\n      }\\n    }\\n  \",\"operationName\":\"IntrospectionQuery\"}");
     }
 
+    [Fact]
+    public Task ParsingWithVariables()
+    {
+        return Parse("{\"query\":\"{\\n  noAttachment\\n  {\\n    argument\\n  }\\n}\",\"variables\":{\"key\":\"value\"},\"operationName\":\"theOperation\"}");
+    }
+
     async Task Parse(string chars)
     {
         await using var stream = new MemoryStream(Encoding.UTF8.GetBytes(chars)) {Position = 0};


### PR DESCRIPTION
PR for #48 

Believe the issue is caused due to reading with the newer Microsoft JSON library and casting to an older Newtonsoft JSON object.

Not using the JObject and instead getting to a string version, then using the string version of the ToInputs extension method seems to work.

Not sure if this is the best way of converting the inputs to a string, but this seems to work for the test cases we have.

Let me know if there is a better way of getting the string value, or any other issues, happy to help out.

Thanks,
Rhys