### PR TITLE
Throw clearer exceptions from IncomingAttachment()

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <NoWarn>CS1591;NU5104;NU1608;NU1109</NoWarn>
-    <Version>8.2.1</Version>
+    <Version>8.2.2</Version>
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <LangVersion>preview</LangVersion>
     <PackageTags>GraphQL, Attachments</PackageTags>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -12,7 +12,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Primitives" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="Microsoft.Sbom.Targets" Version="4.1.5" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageVersion Include="ProjectDefaults" Version="1.0.173" />

--- a/src/GraphQL.Attachments/Contexts/ContextualAttachments.cs
+++ b/src/GraphQL.Attachments/Contexts/ContextualAttachments.cs
@@ -6,7 +6,7 @@ public static class ContextualAttachments
         context.GetAttachmentContext().Incoming;
 
     public static AttachmentStream IncomingAttachment<TSource>(this IResolveFieldContext<TSource> context) =>
-        context.IncomingAttachments().Single().Value;
+        context.IncomingAttachments().GetValue();
 
     public static AttachmentStream IncomingAttachment<TSource>(this IResolveFieldContext<TSource> context, string name) =>
         FindSingle(name, context.IncomingAttachments());
@@ -15,7 +15,7 @@ public static class ContextualAttachments
         context.GetAttachmentContext().Incoming;
 
     public static AttachmentStream IncomingAttachment(this IResolveFieldContext context) =>
-        context.IncomingAttachments().Single().Value;
+        context.IncomingAttachments().GetValue();
 
     public static AttachmentStream IncomingAttachment(this IResolveFieldContext context, string name) =>
         FindSingle(name, context.IncomingAttachments());

--- a/src/GraphQL.Attachments/Contexts/IncomingAttachments.cs
+++ b/src/GraphQL.Attachments/Contexts/IncomingAttachments.cs
@@ -15,12 +15,17 @@ public class IncomingAttachments :
 
     public AttachmentStream GetValue()
     {
-        if (TryGetValue(out var stream))
+        if (Count == 0)
         {
-            return stream;
+            throw new("Reading an attachment with no name requires a single attachment to exist, but none were found.");
         }
 
-        throw new("Attachment not found.");
+        if (Count > 1)
+        {
+            throw new($"Reading an attachment with no name is only supported when there is a single attachment. Found {Count} attachments: {string.Join(", ", Keys)}.");
+        }
+
+        return Values.Single();
     }
 
     public bool TryGetValue([NotNullWhen(true)] out AttachmentStream? stream)
@@ -31,19 +36,13 @@ public class IncomingAttachments :
             return false;
         }
 
-        EnsureSingle();
+        if (Count > 1)
+        {
+            throw new($"Reading an attachment with no name is only supported when there is a single attachment. Found {Count} attachments: {string.Join(", ", Keys)}.");
+        }
 
         stream = Values.Single();
-
         return true;
-    }
-
-    void EnsureSingle()
-    {
-        if (Count != 1)
-        {
-            throw new("Reading an attachment with no name is only supported when their is a single attachment.");
-        }
     }
 
     public async ValueTask DisposeAsync()

--- a/src/Tests/IncomingAttachmentsTests.cs
+++ b/src/Tests/IncomingAttachmentsTests.cs
@@ -1,0 +1,70 @@
+[TestFixture]
+public class IncomingAttachmentsTests
+{
+    [Test]
+    public void GetValue_Single_Returns()
+    {
+        var attachments = new IncomingAttachments();
+        var stream = new AttachmentStream("key", new MemoryStream(), 0, new HeaderDictionary());
+        attachments.Add("key", stream);
+
+        Assert.That(attachments.GetValue(), Is.SameAs(stream));
+    }
+
+    [Test]
+    public void GetValue_Empty_Throws()
+    {
+        var attachments = new IncomingAttachments();
+
+        var exception = Assert.Throws<Exception>(() => attachments.GetValue())!;
+        Assert.That(exception.Message, Does.Contain("none were found"));
+    }
+
+    [Test]
+    public void GetValue_Multiple_Throws()
+    {
+        var attachments = new IncomingAttachments
+        {
+            {"first", new("first", new MemoryStream(), 0, new HeaderDictionary())},
+            {"second", new("second", new MemoryStream(), 0, new HeaderDictionary())}
+        };
+
+        var exception = Assert.Throws<Exception>(() => attachments.GetValue())!;
+        Assert.That(exception.Message, Does.Contain("Found 2 attachments"));
+        Assert.That(exception.Message, Does.Contain("first"));
+        Assert.That(exception.Message, Does.Contain("second"));
+    }
+
+    [Test]
+    public void TryGetValue_Empty_ReturnsFalse()
+    {
+        var attachments = new IncomingAttachments();
+
+        Assert.That(attachments.TryGetValue(out var stream), Is.False);
+        Assert.That(stream, Is.Null);
+    }
+
+    [Test]
+    public void TryGetValue_Single_ReturnsTrue()
+    {
+        var attachments = new IncomingAttachments();
+        var stream = new AttachmentStream("key", new MemoryStream(), 0, new HeaderDictionary());
+        attachments.Add("key", stream);
+
+        Assert.That(attachments.TryGetValue(out var found), Is.True);
+        Assert.That(found, Is.SameAs(stream));
+    }
+
+    [Test]
+    public void TryGetValue_Multiple_Throws()
+    {
+        var attachments = new IncomingAttachments
+        {
+            {"first", new("first", new MemoryStream(), 0, new HeaderDictionary())},
+            {"second", new("second", new MemoryStream(), 0, new HeaderDictionary())}
+        };
+
+        var exception = Assert.Throws<Exception>(() => attachments.TryGetValue(out _))!;
+        Assert.That(exception.Message, Does.Contain("Found 2 attachments"));
+    }
+}


### PR DESCRIPTION
  GetValue() now distinguishes the empty and multiple-attachment cases
  with descriptive messages (instead of LINQ's "Sequence contains no
  elements"), and the multiple case lists the attachment names. The
  parameterless IncomingAttachment() extensions delegate to GetValue().