### PR TITLE
Improve exception messages for attachment lookups and form parsing

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <NoWarn>CS1591;NU5104;NU1608;NU1109</NoWarn>
-    <Version>8.2.2</Version>
+    <Version>8.2.3</Version>
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <LangVersion>preview</LangVersion>
     <PackageTags>GraphQL, Attachments</PackageTags>

--- a/src/GraphQL.Attachments/Contexts/ContextualAttachments.cs
+++ b/src/GraphQL.Attachments/Contexts/ContextualAttachments.cs
@@ -9,7 +9,7 @@ public static class ContextualAttachments
         context.IncomingAttachments().GetValue();
 
     public static AttachmentStream IncomingAttachment<TSource>(this IResolveFieldContext<TSource> context, string name) =>
-        FindSingle(name, context.IncomingAttachments());
+        context.IncomingAttachments().GetValue(name);
 
     public static IIncomingAttachments IncomingAttachments(this IResolveFieldContext context) =>
         context.GetAttachmentContext().Incoming;
@@ -18,17 +18,7 @@ public static class ContextualAttachments
         context.IncomingAttachments().GetValue();
 
     public static AttachmentStream IncomingAttachment(this IResolveFieldContext context, string name) =>
-        FindSingle(name, context.IncomingAttachments());
-
-    static AttachmentStream FindSingle(string name, IIncomingAttachments attachments)
-    {
-        if (attachments.TryGetValue(name, out var attachment))
-        {
-            return attachment;
-        }
-
-        throw new($"Attachment not found: '{name}'");
-    }
+        context.IncomingAttachments().GetValue(name);
 
     public static IOutgoingAttachments OutgoingAttachments<TSource>(this IResolveFieldContext<TSource> context) =>
         context.GetAttachmentContext().Outgoing;

--- a/src/GraphQL.Attachments/Contexts/IIncomingAttachments.cs
+++ b/src/GraphQL.Attachments/Contexts/IIncomingAttachments.cs
@@ -5,5 +5,6 @@ public interface IIncomingAttachments:
     IAsyncDisposable
 {
     AttachmentStream GetValue();
+    AttachmentStream GetValue(string name);
     bool TryGetValue([NotNullWhen(true)] out AttachmentStream? func);
 }

--- a/src/GraphQL.Attachments/Contexts/IncomingAttachments.cs
+++ b/src/GraphQL.Attachments/Contexts/IncomingAttachments.cs
@@ -28,6 +28,21 @@ public class IncomingAttachments :
         return Values.Single();
     }
 
+    public AttachmentStream GetValue(string name)
+    {
+        if (TryGetValue(name, out var attachment))
+        {
+            return attachment;
+        }
+
+        if (Count == 0)
+        {
+            throw new($"Attachment '{name}' not found. No attachments are available.");
+        }
+
+        throw new($"Attachment '{name}' not found. Available attachments: {string.Join(", ", Keys)}.");
+    }
+
     public bool TryGetValue([NotNullWhen(true)] out AttachmentStream? stream)
     {
         if (Count == 0)

--- a/src/GraphQL.Attachments/HttpReaderWriter_Request.cs
+++ b/src/GraphQL.Attachments/HttpReaderWriter_Request.cs
@@ -65,7 +65,7 @@ public partial class HttpReaderWriter
 
         if (queryValues.Count != 1)
         {
-            throw new("Expected 'query' to have a single value.");
+            throw new($"Expected 'query' to have a single value, but found {queryValues.Count} values.");
         }
 
         var operation = ReadOperation(tryGetValue);
@@ -85,7 +85,7 @@ public partial class HttpReaderWriter
             return operationValues.ToString();
         }
 
-        throw new("Expected 'operationName' to have a single value.");
+        throw new($"Expected 'operationName' to have a single value, but found {operationValues.Count} values.");
     }
 
     Inputs? GetInputs(TryGetValue tryGetValue)
@@ -97,7 +97,7 @@ public partial class HttpReaderWriter
 
         if (values.Count != 1)
         {
-            throw new("Expected 'variables' to have a single value.");
+            throw new($"Expected 'variables' to have a single value, but found {values.Count} values.");
         }
 
         var json = values.ToString();

--- a/src/Tests/IncomingAttachmentsTests.cs
+++ b/src/Tests/IncomingAttachmentsTests.cs
@@ -67,4 +67,39 @@ public class IncomingAttachmentsTests
         var exception = Assert.Throws<Exception>(() => attachments.TryGetValue(out _))!;
         Assert.That(exception.Message, Does.Contain("Found 2 attachments"));
     }
+
+    [Test]
+    public void GetValueByName_Found_Returns()
+    {
+        var attachments = new IncomingAttachments();
+        var stream = new AttachmentStream("key", new MemoryStream(), 0, new HeaderDictionary());
+        attachments.Add("key", stream);
+
+        Assert.That(attachments.GetValue("key"), Is.SameAs(stream));
+    }
+
+    [Test]
+    public void GetValueByName_Empty_Throws()
+    {
+        var attachments = new IncomingAttachments();
+
+        var exception = Assert.Throws<Exception>(() => attachments.GetValue("missing"))!;
+        Assert.That(exception.Message, Does.Contain("'missing'"));
+        Assert.That(exception.Message, Does.Contain("No attachments are available"));
+    }
+
+    [Test]
+    public void GetValueByName_NotFound_ListsAvailable()
+    {
+        var attachments = new IncomingAttachments
+        {
+            {"first", new("first", new MemoryStream(), 0, new HeaderDictionary())},
+            {"second", new("second", new MemoryStream(), 0, new HeaderDictionary())}
+        };
+
+        var exception = Assert.Throws<Exception>(() => attachments.GetValue("missing"))!;
+        Assert.That(exception.Message, Does.Contain("'missing'"));
+        Assert.That(exception.Message, Does.Contain("first"));
+        Assert.That(exception.Message, Does.Contain("second"));
+    }
 }

--- a/src/Tests/RequestReaderTests.cs
+++ b/src/Tests/RequestReaderTests.cs
@@ -120,6 +120,80 @@ public class RequestReaderTests
     }
 
     [Test]
+    public void ReadPost_MissingQuery_Throws()
+    {
+        var mockHttpRequest = new MockHttpRequest
+        {
+            Form = new FormCollection(new(), new FormFileCollection()),
+        };
+        var exception = Assert.ThrowsAsync<Exception>(() => readerWriter.ReadPost(mockHttpRequest))!;
+        Assert.That(exception.Message, Does.Contain("Expected to find a form value named 'query'"));
+    }
+
+    [Test]
+    public void ReadPost_MultipleQueryValues_Throws()
+    {
+        var mockHttpRequest = new MockHttpRequest
+        {
+            Form = new FormCollection(
+                new()
+                {
+                    {
+                        "query", new(["one", "two"])
+                    }
+                },
+                new FormFileCollection()),
+        };
+        var exception = Assert.ThrowsAsync<Exception>(() => readerWriter.ReadPost(mockHttpRequest))!;
+        Assert.That(exception.Message, Does.Contain("Expected 'query' to have a single value"));
+        Assert.That(exception.Message, Does.Contain("found 2 values"));
+    }
+
+    [Test]
+    public void ReadPost_MultipleOperationNameValues_Throws()
+    {
+        var mockHttpRequest = new MockHttpRequest
+        {
+            Form = new FormCollection(
+                new()
+                {
+                    {
+                        "query", new("theQuery")
+                    },
+                    {
+                        "operationName", new(["one", "two"])
+                    }
+                },
+                new FormFileCollection()),
+        };
+        var exception = Assert.ThrowsAsync<Exception>(() => readerWriter.ReadPost(mockHttpRequest))!;
+        Assert.That(exception.Message, Does.Contain("Expected 'operationName' to have a single value"));
+        Assert.That(exception.Message, Does.Contain("found 2 values"));
+    }
+
+    [Test]
+    public void ReadPost_MultipleVariablesValues_Throws()
+    {
+        var mockHttpRequest = new MockHttpRequest
+        {
+            Form = new FormCollection(
+                new()
+                {
+                    {
+                        "query", new("theQuery")
+                    },
+                    {
+                        "variables", new(["one", "two"])
+                    }
+                },
+                new FormFileCollection()),
+        };
+        var exception = Assert.ThrowsAsync<Exception>(() => readerWriter.ReadPost(mockHttpRequest))!;
+        Assert.That(exception.Message, Does.Contain("Expected 'variables' to have a single value"));
+        Assert.That(exception.Message, Does.Contain("found 2 values"));
+    }
+
+    [Test]
     public async Task ReadPost()
     {
         var attachment1Bytes = "Attachment1 Text"u8.ToArray();


### PR DESCRIPTION
  Named attachment lookup now reports the requested name plus either
  "no attachments available" or the available keys. Form parsing errors
  for query/operationName/variables now include the actual value count.
  The named-lookup logic moves onto IIncomingAttachments.GetValue(name)
  so it parallels the existing parameterless GetValue() and is
  directly testable.